### PR TITLE
Change Heroku Demo Server Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ PassWall Mobile is a mobile client for PassWall API written with Flutter.
 
 1. Don't mess with the user interface. The design guide has not been released yet.
 
-> When you want to connect to the localhost server with the Android emulator, you connect to the emulator's localhost server and you get an error. Instead, try connecting to the [Heroku Demo server](https://passwall-demo.herokuapp.com).
+> When you want to connect to the localhost server with the Android emulator, you connect to the emulator's localhost server and you get an error. Instead, try connecting to the [Heroku Demo server](https://passwall-server.herokuapp.com).
 
 ## Mile Stones
 


### PR DESCRIPTION
The url was not working and in this issue #6 there is another url so I changed the url in Readme as well.