### PR TITLE
Fix ios textfield long press crash

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,8 @@ class MyApp extends StatelessWidget {
       localizationsDelegates: [
           AppLocalizationDelegate(),
           GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate
       ],
       localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
         if (locale == null) {


### PR DESCRIPTION
Fix ios textfield long press crash by adding "GlobalCupertinoLocalizations.delegate" to "localizationsDelegates"

https://imgur.com/a/tdCmD3G