### PR TITLE
Null control added for new credential dialog

### DIFF
--- a/lib/widgets/create_fab_widget.dart
+++ b/lib/widgets/create_fab_widget.dart
@@ -19,7 +19,9 @@ class _FABWidgetState extends State<FABWidget> {
         child: Icon(Icons.add),
         onPressed: () {
           dialog().then((data) {
-            widget.hasAdded(data);
+            if (data != null) {
+              widget.hasAdded(data);
+            }
           });
         }
     );


### PR DESCRIPTION
When create new credential dialog cancelled, it give failed assertion.Boolean expression must not be null.Bug fixed.