### PR TITLE
Fix Error: The getter 'headline6' isn't defined for the class 'TextTh…

### DIFF
--- a/lib/widgets/detail_widget.dart
+++ b/lib/widgets/detail_widget.dart
@@ -36,7 +36,7 @@ class _DetailWidgetState extends State<DetailWidget> {
         Text(AppLocalizations.of(context).trans('select'), style: Theme
             .of(context)
             .textTheme
-            .headline6)
+            .title)
       ],
     )
         : ListView(

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -59,7 +59,7 @@ class _ListWidgetState extends State<ListWidget> {
                             Text(AppLocalizations.of(context).trans('no_data'), style: Theme
                                 .of(context)
                                 .textTheme
-                                .headline6)
+                                .title)
                           ],
                         ),
                       );
@@ -110,7 +110,7 @@ class _ListWidgetState extends State<ListWidget> {
                                           style: Theme
                                               .of(context)
                                               .textTheme
-                                              .headline4,
+                                              .display1,
                                         ),
                                         width: 40,
                                         height: 40,


### PR DESCRIPTION
…eme'.

According to Doc textstyle names are changed. I've changed those styles with corresponding ones.
https://api.flutter.dev/flutter/material/TextTheme-class.html